### PR TITLE
Security Upgrades - October 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ npm run es3
 
 # ECMAScript 6/7
 
-The ECMAScript 6/7 script is written in accordance with the ECMA-262 Edition 3. It can be run in Node.js with dyanmic 
-transcompilation with the following command. 
+The ECMAScript 6/7 script is written in accordance with the ECMA-262 Edition 3. It can be run in Node.js 12+ using the 
+following command. 
 
 ```
 npm run es6

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "ecmascript-comparison",
   "version": "1.0.0",
+  "engines" : { "node" : ">=12.0.0" },
   "description": "A comparison of ECMAScript 3 and ECMAScript 6 syntax and features",
   "scripts": {
     "es3": "node es3.js",
-    "es6": "./node_modules/babel-cli/bin/babel-node.js --presets es2015 -- es6.js",
+    "es6": "node es6.js",
     "lint": "./node_modules/eslint/bin/eslint.js es3.js es6.js"
   },
   "repository": {
@@ -18,8 +19,6 @@
   },
   "homepage": "https://github.com/tjdavey/ecmascript-comparison#readme",
   "dependencies": {
-    "babel-cli": "^6.10.1",
-    "babel-preset-es2015": "^6.9.0",
-    "eslint": "^2.13.1"
+    "eslint": "^4.18.2"
   }
 }


### PR DESCRIPTION
- Remove babel (no longer required for Node 12+)
- Upgrade ESlint

Resolves:
- [WS-2018-0592](https://github.com/eslint/eslint/commit/f6901d0bcf6c918ac4e5c6c7c4bddeb2cb715c09)